### PR TITLE
List 'scram' as a system requirement

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,6 +7,7 @@ Date: 2017-5-10
 Author: David J. Silkworth
 Maintainer: Jacob T. Ormerod <jake@openreliability.org>
 Depends: FaultTree
+SystemRequirements: scram
 Description: Fault trees parepared using package FaultTree are given access to advanced calculations on SCRAM.
 URL: http://www.openreliability.org/fault-tree-analysis-on-r/
 LazyLoad: yes


### PR DESCRIPTION
This seems to be the way to define external software as a dependency.
On most platforms,
SCRAM is provided with 'scram' package with a package manager.